### PR TITLE
取引リスト表を横長にする

### DIFF
--- a/kokkofactory/frontend/src/app/web/customers/page.module.css
+++ b/kokkofactory/frontend/src/app/web/customers/page.module.css
@@ -1,6 +1,6 @@
 .container {
   padding: 20px;
-  max-width: 900px;
+  max-width: 100%;
   margin: auto;
 }
 


### PR DESCRIPTION
取引先のリスト表示が画面全体ではなかったため、画面全体になるようにした